### PR TITLE
Update checkm.smk

### DIFF
--- a/metapi/rules/checkm.smk
+++ b/metapi/rules/checkm.smk
@@ -96,7 +96,7 @@ if config["params"]["checkm"]["do"]:
                 shell('''touch {output.table}''')
                 shell('''mkdir -p {params.data_dir_temp}''')
 
-            shell('''tar -czvf {output.data} {params.data_dir_temp}/''')
+            shell('''tar --warning=no-file-changed -czvf {output.data} {params.data_dir_temp}/''')
             shell('''rm -rf {params.data_dir_temp}''')
 
 


### PR DESCRIPTION
I found that problem happened in rule "checkm_lineage_wf": Command 'set -euo pipefail;  tar -czvf xxx/xxx/xx.data.tar xxx/xxx/xx/' returned non-zero exit. Suggest add "--warning=no-file-changed" to tar.