### PR TITLE
deepvirfinder now added to checkv

### DIFF
--- a/metapi/config/config.yaml
+++ b/metapi/config/config.yaml
@@ -303,7 +303,7 @@ params:
     do: True
     threads: 8
     db: /home/jiezhu/databases/ecogenomics/CheckV/checkv-db-v1.4
-    checkv_identifier: ["virsorter2", "phamb", "dbscan_swa"]
+    checkv_identifier: ["virsorter2", "phamb", "dbscan_swa", "deepvirfinder"]
 
   dereplicate:
     cdhit:

--- a/metapi/rules/annotation.smk
+++ b/metapi/rules/annotation.smk
@@ -125,18 +125,19 @@ if config["params"]["annotation"]["dbscan_swa"]["do"]:
                  "scaftigs_merged/{binning_group}.{assembler}/{binning_group}.{assembler}.metadata.tsv.gz"),
             all_fna = get_dbscan_swa_merged_output
         output:
-            os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa/distribution_done")
+            assembly_fna = os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa/{binning_group}.{assembly_group}.{assembler}.dbscan_swa.combined.fa.gz"),
+            done = os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa/distribution_done")
         params:
-            working_dir = os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa"),
-            assembly_fna = os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa/{binning_group}.{assembly_group}.{assembler}.dbscan_swa.combined.fa"),
+            working_dir = os.path.join(config["output"]["identify"], "vmags/{binning_group}.{assembly_group}.{assembler}/dbscan_swa"), 
             assembly_group = "{assembly_group}"
         run:
             shell("rm -rf {params.working_dir}")
             shell("mkdir -p {params.working_dir}")
-            shell("touch {params.assembly_fna}")
+            # shell("touch {params.assembly_fna}")
 
             import pandas as pd
             from Bio import SeqIO
+            import gzip
 
             ### record assembly_group : alias ###
             tab = pd.read_table(input.metadata)
@@ -149,11 +150,11 @@ if config["params"]["annotation"]["dbscan_swa"]["do"]:
                 if assembly_vamb_id[vamb_id] != params.assembly_group:
                     # print(vamb_id, assembly_vamb_id[vamb_id])
                     continue
-                with open(params.assembly_fna, "a") as f:
+                with gzip.open(output.assembly_fna, "at") as f:
                     f.write(record.format("fasta"))
 
-            shell("gzip -f {params.assembly_fna}")
-            shell("touch {output}")
+            # shell("gzip -f {params.assembly_fna}")
+            shell("touch {output.done}")
 
     rule annotation_prophage_dbscan_swa_all:
         input:

--- a/metapi/rules/annotation.smk
+++ b/metapi/rules/annotation.smk
@@ -144,15 +144,20 @@ if config["params"]["annotation"]["dbscan_swa"]["do"]:
             assembly_vamb_id = {vamb_id : binning_assembly.split(".")[-1] for vamb_id, binning_assembly in zip(tab.iloc[:,1], tab.iloc[:, 0])}
 
             ### read the prophage fna ###
+            n = 0
             for record in SeqIO.parse(input.all_fna[0], 'fasta'):
                 desc = record.description
                 vamb_id = desc.split("|")[0].split("C")[0]
                 if assembly_vamb_id[vamb_id] != params.assembly_group:
                     # print(vamb_id, assembly_vamb_id[vamb_id])
                     continue
+                n += 1
                 with gzip.open(output.assembly_fna, "at") as f:
                     f.write(record.format("fasta"))
 
+            if n == 0:
+                with gzip.open(output.assembly_fna, "wt") as f:
+                    f.write("")
             # shell("gzip -f {params.assembly_fna}")
             shell("touch {output.done}")
 

--- a/metapi/rules/annotation.smk
+++ b/metapi/rules/annotation.smk
@@ -145,18 +145,17 @@ if config["params"]["annotation"]["dbscan_swa"]["do"]:
 
             ### read the prophage fna ###
             n = 0
-            for record in SeqIO.parse(input.all_fna[0], 'fasta'):
-                desc = record.description
-                vamb_id = desc.split("|")[0].split("C")[0]
-                if assembly_vamb_id[vamb_id] != params.assembly_group:
-                    # print(vamb_id, assembly_vamb_id[vamb_id])
-                    continue
-                n += 1
-                with gzip.open(output.assembly_fna, "at") as f:
+            with gzip.open(output.assembly_fna, "at") as f:
+                for record in SeqIO.parse(input.all_fna[0], 'fasta'):
+                    desc = record.description
+                    vamb_id = desc.split("|")[0].split("C")[0]
+                    if assembly_vamb_id[vamb_id] != params.assembly_group:
+                        # print(vamb_id, assembly_vamb_id[vamb_id])
+                        continue
+                    n += 1
                     f.write(record.format("fasta"))
 
-            if n == 0:
-                with gzip.open(output.assembly_fna, "wt") as f:
+                if n == 0:
                     f.write("")
             # shell("gzip -f {params.assembly_fna}")
             shell("touch {output.done}")

--- a/metapi/rules/identify_multi.smk
+++ b/metapi/rules/identify_multi.smk
@@ -241,6 +241,60 @@ if config["params"]["identify"]["phamb"]["do"] and config["params"]["identify"][
                         for line in ih:
                             oh.write(f'''{assembly_group}C{line}''')
 
+    rule identify_phamb_deepvirfinder_extract_contigs:
+        input:
+            scaftigs = os.path.join(
+	                 config["output"]["assembly"],
+	                 "scaftigs_merged/{binning_group}.{assembler}/{binning_group}.{assembler}.merged.scaftigs.fa.gz"),
+            dvf_anno = os.path.join(
+                     config["output"]["identify"],
+                     "vmags/{binning_group}.{assembly_group}.{assembler}/deepvirfinder/{binning_group}.{assembly_group}.{assembler}.scaftigs.fa.gz_gt"+
+                         str(config["params"]["identify"]["deepvirfinder"]["min_length"])+
+                         "bp_dvfpred.txt.gz"),
+            metadata = os.path.join(config["output"]["assembly"],
+                         "scaftigs_merged/{binning_group}.{assembler}/{binning_group}.{assembler}.metadata.tsv.gz")
+
+        params:
+            assembly_group = "{assembly_group}"
+
+        output:
+            assembly_fna = os.path.join(
+                                       config["output"]["identify"],
+                                        "vmags/{binning_group}.{assembly_group}.{assembler}/deepvirfinder/{binning_group}.{assembly_group}.{assembler}.deepvirfinder.combined.fa.gz"),
+            done = os.path.join(
+                  config["output"]["identify"],
+                  "vmags/{binning_group}.{assembly_group}.{assembler}/deepvirfinder/distribution_done")
+
+        run:
+            from Bio import SeqIO
+            import gzip
+
+            ### record assembly_group : alias ###
+            tab = pd.read_table(input.metadata)
+            # vamb_id_assembly = {vamb_id : binning_assembly.split(".")[-1] for vamb_id, binning_assembly in zip(tab.iloc[:,1], tab.iloc[:, 0])}
+            assembly_vamb_id = {binning_assembly.split(".")[-1] : vamb_id for vamb_id, binning_assembly in zip(tab.iloc[:,1], tab.iloc[:, 0])}
+            # seems like metapi.get_samples_id_by_binning_group(SAMPLES, wildcards.binning_group) will do the trick
+
+            # shell("zcat {input.dvf_anno} | perl -lane 's/\s.*?\t/\t/; print' > {params.temp_metadata}")
+            dvf_dict = dict() #defaultdict(int)
+            vamb_id = assembly_vamb_id[params.assembly_group]
+            with gzip.open(input.dvf_anno, "rt") as records:
+                records.readline()# title line
+                for record in records:
+                    name, length, score, p = record.split("\t")
+                
+                    if float(score) > 0.5 and float(p) < 0.05:
+                        name = name.split(" ")[0]
+                        name = vamb_id + 'C' + name
+                        dvf_dict[name] = 1
+                    # print(record, end="")
+
+            dvf_viral_list = list(dvf_dict.keys())
+            with gzip.open(output.assembly_fna, "at") as f:
+                for record in SeqIO.parse(gzip.open(input.scaftigs, 'rt'), 'fasta'):
+                    if record.description in dvf_viral_list:
+                        f.write(record.format("fasta"))
+            shell("touch {output.done}")
 
     rule identify_phamb_randomforest:
         input:
@@ -355,6 +409,13 @@ if config["params"]["identify"]["phamb"]["do"] and config["params"]["identify"][
                     config["output"]["identify"],
                     "vmags/{binning_group}.{assembly_group}.{assembler}/phamb/{binning_group}.{assembly_group}.{assembler}.phamb.combined.fa.gz"),
                 zip,
+                binning_group=ASSEMBLY_GROUPS["binning_group"],
+                assembly_group=ASSEMBLY_GROUPS["assembly_group"],
+                assembler=ASSEMBLY_GROUPS["assembler"]),
+            expand(
+                os.path.join(
+                    config["output"]["identify"],
+                    "vmags/{binning_group}.{assembly_group}.{assembler}/deepvirfinder/{binning_group}.{assembly_group}.{assembler}.deepvirfinder.combined.fa.gz"),
                 binning_group=ASSEMBLY_GROUPS["binning_group"],
                 assembly_group=ASSEMBLY_GROUPS["assembly_group"],
                 assembler=ASSEMBLY_GROUPS["assembler"])


### PR DESCRIPTION
- Revise identify_multi.smk to distribute the dvf identified viral contigs (the same logic as that for dbscan_swa):
    1. extract dvf identified viral contigs
    2. distribute the them back to each assembly group under 06.identify
    3. these can then be checked by checkv

- config.yaml has been updated accordingly

- annotation.smk has been updated
    1. I/O for distribution optimized (open the output file once only)
    2. output revised and now check(v)_all works